### PR TITLE
Fix `Too many arguments` warning

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -124,14 +124,12 @@ const PingMenuButton = new Lang.Class(
 
         this.tagWatchOUT = GLib.io_add_watch(this.IOchannelOUT, GLib.PRIORITY_DEFAULT,
             GLib.IOCondition.IN | GLib.IOCondition.HUP,
-            Lang.bind(this, this._loadPipeOUT),
-            null
+            Lang.bind(this, this._loadPipeOUT)
         );
 
         this.tagWatchERR = GLib.io_add_watch(this.IOchannelERR, GLib.PRIORITY_DEFAULT,
             GLib.IOCondition.IN | GLib.IOCondition.HUP,
-            Lang.bind(this, this._loadPipeERR),
-            null
+            Lang.bind(this, this._loadPipeERR)
         );
     },
 
@@ -142,7 +140,7 @@ const PingMenuButton = new Lang.Class(
     {
         if (condition != GLib.IOCondition.HUP)
         {
-            let [size, out] = channel.read_to_end(null);
+            let [size, out] = channel.read_to_end();
             
             let result = out.toString().match(/time=(\d*.*)\ ms/m);
 


### PR DESCRIPTION
Fix the warning, which appears about every 5s in /var/log/syslog

> JS WARNING: [/home/user/.local/share/gnome-shell/extensions/iconping@simonebisi.it/extension.js 145]: Too many arguments to method GLib.IOChannel.read_to_end: expected 0, got 1

this fix is a copy of the [pull request](https://github.com/trifonovkv/ping_indicator/pull/11) of ping_indicator.

tested and works.