### PR TITLE
Fix for gnome 3.38

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -53,8 +53,6 @@ const PingMenuButton = new Lang.Class(
 		button = new St.Bin({ style_class: 'panel-button',
                           reactive: true,
                           can_focus: true,
-                          x_fill: true,
-                          y_fill: false,
                           track_hover: true });                     
 
 		this.createPingIcon('icon');


### PR DESCRIPTION
These x_fil and y_fill properties provoke an error when loading extension  "(x_fill|y_fill) is not a property of StBin"